### PR TITLE
Fixes 'record pages' and 'record entries' problems for new Bolt setups

### DIFF
--- a/entry.twig
+++ b/entry.twig
@@ -32,7 +32,7 @@
 		    <div class="featured-image-single">
 		    </div>
 	
-	{% for key,value in record.values if key not in ['id', 'slug', 'datecreated', 'datechanged', 'datepublish', 'datedepublish', 'username', 'status', 'title', 'subtitle', 'ownerid'] %}
+	{% for key,value in record.values if key not in ['id', 'slug', 'datecreated', 'datechanged', 'datepublish', 'datedepublish', 'username', 'status', 'title', 'subtitle', 'ownerid', 'templatefields'] %}
 
                 {% if record.fieldtype(key) == "image" and value != "" %}
 

--- a/record.twig
+++ b/record.twig
@@ -83,7 +83,7 @@
 
                 {% elseif record.fieldtype(key) not in ['templateselect' ] and value != "" %}
 
-                    <p><strong>{{ record.fieldtype(key) }}: </strong>
+                    <p><strong>{{ key }}: </strong>
                         {{ attribute(record, key) }}
                     </p>
 

--- a/record.twig
+++ b/record.twig
@@ -31,8 +31,7 @@
 		    <div class="entry-content">
 		    <div class="featured-image-single">
 		    </div>
-	
-	{% for key,value in record.values if key not in ['id', 'slug', 'datecreated', 'datechanged', 'datepublish', 'datedepublish', 'username', 'status', 'title', 'subtitle', 'ownerid'] %}
+	{% for key,value in record.values if key not in ['id', 'slug', 'datecreated', 'datechanged', 'datepublish', 'datedepublish', 'username', 'status', 'title', 'subtitle', 'ownerid', 'templatefields'] %}
 
                 {% if record.fieldtype(key) == "image" and value != "" %}
 
@@ -82,9 +81,9 @@
                         {{ attribute(record, key)|join(", ") }}
                     </p>
 
-                {% elseif record.fieldtype(key) not in ['templateselect'] and value != "" %}
+                {% elseif record.fieldtype(key) not in ['templateselect' ] and value != "" %}
 
-                    <p><strong>{{ key }}: </strong>
+                    <p><strong>{{ record.fieldtype(key) }}: </strong>
                         {{ attribute(record, key) }}
                     </p>
 


### PR DESCRIPTION
Errors when printing {{attribute(record, key}} in record.twig and entry.twig are fixed in these commits. 